### PR TITLE
use std::vector rather than built in arrays for object pools

### DIFF
--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -4,6 +4,8 @@
 #include "maths.hpp"
 #include "printing.hpp"
 #include "stage.hpp"
+#include "util.hpp"
+
 void updateAABBS(Stage& stage) {
 	for(AABB& aabb : stage.aabbs) {
 		switch (aabb.type) {
@@ -49,8 +51,8 @@ AABB::AABB(const Ship& ship) {
 
 AABB::AABB(const Sea& sea) {
 	float maxHeight = sea.level;
-	for(short i = 0; i < sea.numWaves; ++i) {
-		maxHeight = std::max(maxHeight, heightAtX(sea.waves[i], sea.waves[i].position.x));
+	for (const Wave& wave : sea.waves) {
+		maxHeight = std::max(maxHeight, wave.heightAtX(wave.position.x));
 	}
 	lower = {0.f, 0.f};
 	upper = {STAGE_WIDTH, maxHeight};

--- a/src/aabb.cpp
+++ b/src/aabb.cpp
@@ -4,6 +4,23 @@
 #include "maths.hpp"
 #include "printing.hpp"
 #include "stage.hpp"
+void updateAABBS(Stage& stage) {
+	for(AABB& aabb : stage.aabbs) {
+		switch (aabb.type) {
+			case ROCK:
+				aabb = AABB(*findRock(stage, aabb.id));
+				break;
+			case SHIP:
+				aabb = AABB(stage.ship);
+				break;
+			case PLATFORM:
+				aabb = AABB(*findPlatform(stage, aabb.id));
+				break;
+			default:
+				break;
+		}
+	}
+}
 
 AABB::AABB(const Platform& platform) {
 	boundingPoints(platform.shape, lower, upper);
@@ -42,25 +59,20 @@ AABB::AABB(const Sea& sea) {
 }
 
 uint8_t createAABB(Stage& stage, AABB aabb) {
-	sorted_insert(aabb, stage.aabbs, stage.numAABBS, [](AABB& a, AABB&b) { return a.lower.x < b.lower.x; });
+	sorted_insert<AABB, AABBIt>(stage.aabbs, aabb, [](AABB a, AABB b) { return a.lower.x < b.lower.x; });
 	return aabb.id;
 }
 
-int deleteAABBByIdx(Stage& stage, int aabb_idx) {
-	stage.aabbs[aabb_idx] = AABB();
-	for(short j = aabb_idx; j < stage.numAABBS-1; ++j) {
-		stage.aabbs[j] = stage.aabbs[j+1];
-		stage.aabbs[j+1] = AABB();
-	}
-	return --stage.numAABBS;
+AABBIt findAABB(Stage& stage, uint8 aabbId) {
+	AABBIt search = std::find_if(stage.aabbs.begin(), stage.aabbs.end(), [aabbId](AABB& aabb) -> bool { return aabb.id == aabbId; });
+	assert(search != stage.aabbs.end()); // don't look for unicorns!
+	return search;
 }
 
-int deleteAABBById(Stage& stage, uint8_t aabb_id) {
-	for(short i = 0; i < stage.numAABBS; ++i) {
-		if(stage.aabbs[i].id == aabb_id) {
-			return deleteAABBByIdx(stage, i);
-		}
-	}
-	assert(false);
-	return -1;
+AABBIt deleteAABB(Stage& stage, AABBIt aabbIt) {
+	return stage.aabbs.erase(aabbIt);
+}
+
+AABBIt deleteAABB(Stage& stage, uint8 aabbId) {
+	return stage.aabbs.erase(findAABB(stage, aabbId));
 }

--- a/src/aabb.hpp
+++ b/src/aabb.hpp
@@ -4,6 +4,7 @@
 #include "entity.hpp"
 #include "prelude.hpp"
 #include "maths.hpp"
+#include "typedefs.hpp"
 
 
 struct AABB{
@@ -18,9 +19,13 @@ struct AABB{
 	uint8_t id = 0;
 };
 
+typedef std::vector<AABB>::iterator AABBIt;
+
+void updateAABBS(Stage& stage);
 uint8_t createAABB(Stage& stage, AABB aabb);
-int deleteAABBByIdx(Stage& stage, int aabb_idx);
-int deleteAABBById(Stage& stage, uint8_t aabb_id);
+AABBIt findAABB(Stage& stage, uint8 aabbId);
+AABBIt deleteAABB(Stage& stage, AABBIt aabbIt);
+AABBIt deleteAABB(Stage& stage, uint8 aabbId);
 
 inline float area(const AABB aabb) {
 	return (aabb.upper.x - aabb.lower.x) * (aabb.upper.y - aabb.lower.y);
@@ -31,9 +36,28 @@ inline bool operator==(const AABB& a, const AABB& b) {
 }
 
 struct AABBPair{
+	enum Axis : uint8 {
+		NONE = 0,
+		X_AXIS = 1 << 0,
+		Y_AXIS = 1 << 1,
+		BOTH = 3
+	};
+
+	Axis overlap = NONE;
 	AABB a;
 	AABB b;
+
+	void setAxis(Axis axis) {
+		overlap = (Axis)(overlap | axis);
+	}
+	void unsetAxis(Axis axis) {
+		overlap = (Axis)(overlap & ~axis);
+	}
 };
+
+inline bool collides(AABBPair pair) {
+	return pair.overlap == (AABBPair::X_AXIS | AABBPair::Y_AXIS);
+}
 
 inline bool operator==(const AABBPair& a, const AABBPair& b){
 	return a.a == b.a && a.b == b.b;

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -76,14 +76,14 @@ void dispatchPotentialCollision(Stage& stage, const AABBPair& pair) {
 	// Platform* aPlatform = nullptr;
 	switch(pair.a.type) {
 		case ROCK:	aRock = &*findRock(stage, pair.a.id); break;
-		case PLATFORM:	aPlatform = &findPlatform(stage, pair.a.id); break;
+		case PLATFORM:	aPlatform = &*findPlatform(stage, pair.a.id); break;
 		default: break;
 	}
 	Rock* bRock = nullptr;
 	Platform* bPlatform= nullptr;
 	switch(pair.b.type) {
 		case ROCK:	bRock = &*findRock(stage, pair.b.id); break;
-		case PLATFORM:	bPlatform = &findPlatform(stage, pair.b.id); break;
+		case PLATFORM:	bPlatform = &*findPlatform(stage, pair.b.id); break;
 		default: break;
 	}
 	switch(pair.a.type | pair.b.type){

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -23,20 +23,16 @@ void resolveCollisions(Stage& stage) {
 	for(int i = 0; i < numAABBs; ++i) {
 		switch (aabbs[i].type) {
 		case ROCK:
-			{
-				int rock_idx = binary_find_where(aabbs[i].id, stage.rocks, stage.numRocks, [](const Rock& rock){ return rock.id;});
-				assert(rock_idx > -1);
-				aabbs[i] = AABB(stage.rocks[rock_idx]);
-			}
-		break;
+			aabbs[i] = AABB(*findRock(stage, aabbs[i].id));
+			break;
 		case SHIP:
 			aabbs[i] = AABB(stage.ship);
-		break;
+			break;
 		case PLATFORM:
 			// NOTE: since platforms are static, their AABBS shouldn't need updating, I'll leave the case here in case
-		break;
+			break;
 		default:
-		break;
+			break;
 		}
 	}
 	// then resort the list (insertion sort is a "slow" sorting method
@@ -79,14 +75,14 @@ void dispatchPotentialCollision(Stage& stage, const AABBPair& pair) {
 	Platform* aPlatform = nullptr;
 	// Platform* aPlatform = nullptr;
 	switch(pair.a.type) {
-		case ROCK:	aRock = &findRock(stage, pair.a.id); break;
+		case ROCK:	aRock = &*findRock(stage, pair.a.id); break;
 		case PLATFORM:	aPlatform = &findPlatform(stage, pair.a.id); break;
 		default: break;
 	}
 	Rock* bRock = nullptr;
 	Platform* bPlatform= nullptr;
 	switch(pair.b.type) {
-		case ROCK:	bRock = &findRock(stage, pair.b.id); break;
+		case ROCK:	bRock = &*findRock(stage, pair.b.id); break;
 		case PLATFORM:	bPlatform = &findPlatform(stage, pair.b.id); break;
 		default: break;
 	}

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -26,7 +26,7 @@ void resolveCollisions(Stage& stage) {
 	insertion_sort<AABB>(stage.aabbs.begin(), stage.aabbs.end(), aabbSortPredicate);
 
 	std::vector<AABBPair> pairs;
-	pairs.reserve(2*MAX_AABBS); // In a worst case scenario we could really have like MAX_ABBS^2 collisions but let's be optimistic
+	pairs.reserve(2*stage.aabbs.size()); // In a worst case scenario we could really have like # ABBS^2 collisions but let's be optimistic
 
 	AABB seaAAABB = AABB(stage.sea); // because the sea AABB spans the entire stage, we don't want to include it in the sweep list as it will slow down the algorithm
 	// start with the first aabb upper as the max

--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -138,13 +138,13 @@ inline void collideGreen(Rock& rock, Sea& sea) {
 	if(rock.state.type != RockState::FLOATING) {
 		rock.state = {RockState::FLOATING, {0.f}};
 	}
-	if (sea.numWaves < 0) { return; } // nothing to do for no waves
-	int closestWaveIndex = findWaveAtX(sea, rock.shape.position.x);
-	if (closestWaveIndex < 0) {
-		if (sea.numWaves > 0) assert(false);
+	if (sea.waves.size() < 0) { return; } // nothing to do for no waves
+	WaveIt closestWaveIt = findWaveAtPosition(sea, rock.shape.position);
+	if (closestWaveIt == sea.waves.end()) {
+		if (sea.waves.size() > 0) assert(false);
 		return;
 	} // if there are no waves then do nothing
-	const Wave& wave = sea.waves[closestWaveIndex];
+	const Wave& wave = *closestWaveIt;
 	float distFromWave = std::abs(rock.shape.position.x - wave.position.x);
 	if (distFromWave < 0.1) {
 		rock.state = {};
@@ -208,7 +208,7 @@ void collide(Rock& rock, Rock& other_rock) {
 void collide(Rock& rock, Ship& ship) {
 }
 
-void collide(Ship& ship, const Sea& sea) {
+void collide(Ship& ship, Sea& sea) {
 	float seaHeight = heightAtX(sea, ship.shape.position.x);
 	Vector2 lower, upper;
 	boundingPoints(ship.shape, lower, upper);
@@ -225,13 +225,13 @@ void collide(Ship& ship, const Sea& sea) {
 	auto drag = dragForce(ship.velocity, 600.f, mass(ship) * SHIP_AREA_MASS_RATIO);
 	ship.velocity += drag * FIXED_TIMESTEP;
 
-	if (sea.numWaves < 0) { return; } // nothing to do for no waves
-	int closestWaveIndex = findWaveAtX(sea, ship.shape.position.x);
-	if (closestWaveIndex < 0) {
-		if (sea.numWaves > 0) assert(false);
+	if (sea.waves.size() < 0) { return; } // nothing to do for no waves
+	WaveIt closestWaveIt = findWaveAtPosition(sea, ship.shape.position);
+	if (closestWaveIt == sea.waves.end()) {
+		if (sea.waves.size() > 0) assert(false);
 		return;
 	} // if there are no waves then do nothing
-	const Wave& wave = sea.waves[closestWaveIndex];
+	const Wave& wave = *closestWaveIt;
 	float distFromWave = std::abs(ship.shape.position.x - wave.position.x);
 	if (distFromWave < 0.1) {
 		ship.state = {};

--- a/src/collision.hpp
+++ b/src/collision.hpp
@@ -24,8 +24,8 @@ void collide(Rock& rock, Rock& other_rock);
 //  - Sea
 //  - Platforms
 //  - Rocks
-void collide(Ship& ship, const Sea& sea); // a ship probably shouldn't alter a sea
-void collide(Ship& ship, const Platform& platform); // a ship shouldn't alter a platform either
+void collide(Ship& ship, Sea& sea);
+void collide(Ship& ship, const Platform& platform); // a ship shouldn't alter a platform
 void collide(Ship& ship, Rock& rock);
 
 struct Collision {

--- a/src/constants.hpp
+++ b/src/constants.hpp
@@ -12,10 +12,6 @@ const float STAGE_HEIGHT = 	72.f; // meters
 const float FIXED_TIMESTEP = 	1.f/480.f; // seconds (480 Hz)
 const float FRAME_RATE = 		1.f/120.f; // seconds (60 Hz)
 
-const int MAX_ROCKS = 		5;
-const int MAX_WAVES = 		MAX_ROCKS;
-const int MAX_PLATFORMS = 	5;
-const int MAX_AABBS =		MAX_ROCKS + MAX_PLATFORMS + 1; // +1 for ship and
 
 // Physics constants
 // const float GRAVITATIONAL_CONSTANT = 9.8f;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -34,7 +34,7 @@ void drawStage(sf::RenderTarget& target, Stage& stage,  bool showGrid) {
 	drawPlatforms(target, stage);
 	drawSea(target, stage.sea);
 	if(stage.selection.active && stage.selection.state == Selection::PULL && stage.selection.pullPosition != VECTOR2_ZERO) {
-		Rock& rock = findRock(stage, stage.selection.entity.id);
+		Rock& rock = *findRock(stage, stage.selection.entity.id);
 		drawLine(target, rock.shape.position, stage.selection.pullPosition, sf::Color::Blue);
 	}
 	drawRocks(target, stage);
@@ -70,22 +70,15 @@ inline void drawShip(sf::RenderTarget& target, const Ship& ship) {
 }
 
 inline void drawRocks(sf::RenderTarget& target, const Stage& stage) {
-	for (int i = 0; i < stage.numRocks; ++i){
+	for(const Rock& rock : stage.rocks) {
 		sf::Color c;
-		// if (stage.selection.active && stage.rocks[i].id == stage.selection.entity.id) {
-		// 	c = sf::Color::Cyan;
-		// } else if (stage.rocks[i].sized) {
-		// 	c = sf::Color::Red;
-		// } else {
-		// 	c = sf::Color::Green;
-		// }
-		switch(stage.rocks[i].type.type) {
+		switch(rock.type.type) {
 			case RockType::RED: c = sf::Color::Red; break;
 			case RockType::GREEN: c = sf::Color::Green; break;
 			case RockType::BLUE: c = sf::Color::Blue; break;
 		}
-		drawCircle(target, stage.rocks[i].shape, c);
-		drawId(target, stage.rocks[i].id, stage.rocks[i].shape.position);
+		drawCircle(target, rock.shape, c);
+		drawId(target, rock.id, rock.shape.position);
 	}
 }
 
@@ -142,10 +135,10 @@ void drawInfoText(sf::RenderTarget& target, const Stage& stage, float drawDelta,
 		infostream << "Paused Time: 			" << stage.state.paused.time <<std::endl;
 	}
 	infostream << std::endl;
-	infostream << "#Rocks: 					" << stage.numRocks << std::endl;
+	infostream << "#Rocks: 					" << stage.rocks.size() << std::endl;
 	infostream << "#Waves: 					" << stage.sea.numWaves << std::endl;
 	infostream << "#AABBs: 					" << stage.numAABBS << std::endl;
-	if(stage.numRocks > 0 ) {
+	if(stage.rocks.size() > 0 ) {
 		infostream << "P:						" << stage.rocks[0].shape.position<< std::endl;
 		infostream << "V:						" << stage.rocks[0].velocity << std::endl;
 	}

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -137,7 +137,7 @@ void drawInfoText(sf::RenderTarget& target, const Stage& stage, float drawDelta,
 	infostream << std::endl;
 	infostream << "#Rocks: 					" << stage.rocks.size() << std::endl;
 	infostream << "#Waves: 					" << stage.sea.numWaves << std::endl;
-	infostream << "#AABBs: 					" << stage.numAABBS << std::endl;
+	infostream << "#AABBs: 					" << stage.aabbs.size() << std::endl;
 	if(stage.rocks.size() > 0 ) {
 		infostream << "P:						" << stage.rocks[0].shape.position<< std::endl;
 		infostream << "V:						" << stage.rocks[0].velocity << std::endl;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -55,11 +55,7 @@ inline void drawSea(sf::RenderTarget& target, const Sea& sea) {
 	float step = 1 / pixelsPerUnit(target).x;
 	for (float i = 0; i < STAGE_WIDTH; i += step)
 	{
-		// this draw pattern causes the gpu hardware to interpolate the color alpha
-		// from 1 to 0 (found this by accident but I like it)
 		vertices.push_back(sf::Vertex(game2ScreenPos(target, {i, heightAtX(sea, i)}), SEA_COLOR));
-		// vertices.push_back(sf::Vertex(game2ScreenPos(target, {i+step, heightAtX(sea, i+step)}), SEA_COLOR));
-		// vertices.push_back(sf::Vertex(game2ScreenPos(target, {i, 0}), SEA_COLOR));
 	}
 	target.draw(&vertices[0], vertices.size(), sf::LineStrip);
 }
@@ -136,7 +132,7 @@ void drawInfoText(sf::RenderTarget& target, const Stage& stage, float drawDelta,
 	}
 	infostream << std::endl;
 	infostream << "#Rocks: 					" << stage.rocks.size() << std::endl;
-	infostream << "#Waves: 					" << stage.sea.numWaves << std::endl;
+	infostream << "#Waves: 					" << stage.sea.waves.size()<< std::endl;
 	infostream << "#AABBs: 					" << stage.aabbs.size() << std::endl;
 	if(stage.rocks.size() > 0 ) {
 		infostream << "P:						" << stage.rocks[0].shape.position<< std::endl;
@@ -152,7 +148,6 @@ inline void drawText(sf::RenderTarget& target, std::string text, sf::Vector2f po
 	sf::Text sfText((sf::String)text, font, size);
 	sfText.setFillColor(sf::Color::White);
 	sfText.setPosition(position);
-	auto blah = sfText.getLocalBounds();
 	if(centered) {
 		sf::FloatRect bounds = sfText.getGlobalBounds();
 		sfText.setOrigin(bounds.width/2, bounds.height/2);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -83,9 +83,9 @@ inline void drawRocks(sf::RenderTarget& target, const Stage& stage) {
 }
 
 inline void drawPlatforms(sf::RenderTarget& target, const Stage& stage) {
-	for (int i = 0; i < stage.numPlatforms; ++i){
-		drawPolygon(target, stage.platforms[i].shape, sf::Color::Magenta);
-		drawId(target, stage.platforms[i].id, stage.platforms[i].shape.position);
+	for (const Platform& platform : stage.platforms) {
+		drawPolygon(target, platform.shape, sf::Color::Magenta);
+		drawId(target, platform.id, platform.shape.position);
 	}
 }
 
@@ -142,7 +142,8 @@ void drawInfoText(sf::RenderTarget& target, const Stage& stage, float drawDelta,
 		infostream << "P:						" << stage.rocks[0].shape.position<< std::endl;
 		infostream << "V:						" << stage.rocks[0].velocity << std::endl;
 	}
-	infostream << "RockState:				" << (int)stage.rocks[0].state.type << std::endl;
+	if (!stage.rocks.empty())
+		infostream << "RockState:				" << (int)stage.rocks[0].state.type << std::endl;
 	infostream << "ShipState:				" << (int)stage.ship.state.type << std::endl;
 	drawText(target, infostream.str(), {3, 3}, 13);
 }

--- a/src/graphics.hpp
+++ b/src/graphics.hpp
@@ -32,7 +32,7 @@ inline void drawPolygon(sf::RenderTarget&, const Polygon<N>&, sf::Color);
 inline void drawText(sf::RenderTarget&, std::string, sf::Vector2f, int=15, bool=false);
 inline void drawId(sf::RenderTarget&, int, sf::Vector2f);
 inline void drawId(sf::RenderTarget&, int, Vector2);
-inline void drawCircle(sf::RenderTarget&, const Circle&, sf::Color, bool=false);
+inline void drawCircle(sf::RenderTarget&, const Circle&, sf::Color, bool fill=false);
 inline void drawLine(sf::RenderTarget&, Vector2, Vector2, sf::Color);
 
 inline sf::Vector2f game2ScreenPos(const sf::RenderTarget&, Vector2);

--- a/src/maths.hpp
+++ b/src/maths.hpp
@@ -13,6 +13,12 @@ T sign(T t) {
 	return (t == (T)0) ? (T)0 : t / abs(t);
 }
 
+template <typename T>
+T signOf(T t) {
+	return sign<T>(t);
+}
+
+
 /***********
  * Vectors *
  ***********/

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -1,40 +1,27 @@
+#include "typedefs.hpp"
 #include "platform.hpp"
 #include "stage.hpp"
 
-uint8_t createPlatform(Stage& stage, Vector2 position, float width, float height) {
-	if (stage.numPlatforms >= MAX_PLATFORMS) {
-		return -1;
-	}
-	int new_platform_idx = stage.numPlatforms;
-	Platform& platform = *(stage.platforms + new_platform_idx);
-	platform = Platform();
+uint8 createPlatform(Stage& stage, Vector2 position, float width, float height) {
+	Platform platform;
 	platform.shape = makeRectangle(position, width, height);
 	platform.id = ++stage.id_src;
-	stage.numPlatforms++;
+	stage.platforms.push_back(platform);
 	createAABB(stage, AABB(platform));
 	return platform.id;
 }
 
-uint8_t createPlatform(Stage& stage, Rectangle rect) {
-	if (stage.numPlatforms >= MAX_PLATFORMS) {
-		return -1;
-	}
-	int new_platform_idx = stage.numPlatforms;
-	Platform& platform = *(stage.platforms + new_platform_idx);
-	platform = Platform();
+uint8 createPlatform(Stage& stage, Rectangle rect) {
+	Platform platform;
 	platform.shape = rect;
 	platform.id = ++stage.id_src;
-	stage.numPlatforms++;
+	stage.platforms.push_back(platform);
 	createAABB(stage, AABB(platform));
 	return platform.id;
 }
 
-Platform& findPlatform(Stage& stage, uint8_t platform_id) {
-	int platform_idx = binary_find_where(platform_id, stage.platforms, stage.numPlatforms, [](const Platform& platform) {return platform.id;});
-	// NOTE: binary_find_where will return -1 if it doesn't find the id you ask for
-	// this means that if you look for a platform that isn't there ...
-	assert(platform_idx > -1); // ... then this assertion will fail ...
-	// ... and you will die
-	// So don't go lookin for no imaginary platforms
-	return stage.platforms[platform_idx];
+PlatformIt findPlatform(Stage& stage, uint8 platformId) {
+	PlatformIt platformIt = std::lower_bound(stage.platforms.begin(), stage.platforms.end(), platformId, [](Platform& p, uint8 id) -> bool { return p.id < id; });
+	assert(platformIt != stage.platforms.end()); // ... then this assertion will fail ...
+	return platformIt;
 }

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -2,16 +2,20 @@
 #include "aabb.hpp"
 #include "constants.hpp"
 #include "maths.hpp"
+#include "typedefs.hpp"
 #include "util.hpp"
 
 struct Platform {
 	Rectangle shape;
-	uint8_t id = 0;
+	uint8 id = 0;
 };
 
-uint8_t createPlatform(Stage& stage, Vector2 position, float width, float height);
-uint8_t createPlatform(Stage& stage, Rectangle);
-Platform& findPlatform(Stage& stage, uint8_t platform_id);
+typedef std::vector<Platform>::iterator PlatformIt;
+
+uint8 createPlatform(Stage& stage, Vector2 position, float width, float height);
+uint8 createPlatform(Stage& stage, Rectangle);
+PlatformIt findPlatform(Stage& stage, uint8 platform_id);
+
 inline float mass(const Platform& platform) {
 	return area(platform.shape) * PLATFORM_AREA_MASS_RATIO;
 }

--- a/src/prelude.hpp
+++ b/src/prelude.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+
 struct AABB;
 struct AABBPair;
 struct Game;

--- a/src/rock.cpp
+++ b/src/rock.cpp
@@ -120,12 +120,12 @@ RockIt deleteRock(Stage& stage, uint8 rockId) {
 
 RockIt findRock(Stage& stage, uint8 rockId) {
 	RockIt rockIt = std::lower_bound(stage.rocks.begin(), stage.rocks.end(), rockId, [](const Rock& r, uint8 id) -> bool { return r.id < id; });
-	assert(rockIt != stage.rocks.end()); 
+	assert(rockIt != stage.rocks.end());
 	return rockIt;
 }
 
 RockIt findRockAtPosition(Stage& stage, Vector2 position) {
-	for(RockIt rockIt = stage.rocks.begin(); rockIt != stage.rocks.end(); ++rockIt){ 
+	for(RockIt rockIt = stage.rocks.begin(); rockIt != stage.rocks.end(); ++rockIt){
 		float dist = magnitude(position - rockIt->shape.position);
 		if (dist <= rockIt->shape.radius) {
 			return rockIt;

--- a/src/rock.cpp
+++ b/src/rock.cpp
@@ -110,7 +110,7 @@ uint8 createRock(Stage& stage, Vector2 position, float radius, RockType type){
 }
 
 RockIt deleteRock(Stage& stage, RockIt rockIt) {
-	deleteAABBById(stage, rockIt->id);
+	deleteAABB(stage, rockIt->id);
 	return stage.rocks.erase(rockIt);
 }
 

--- a/src/rock.hpp
+++ b/src/rock.hpp
@@ -61,17 +61,18 @@ struct Rock {
 	uint8_t id = 0;
 };
 
+typedef std::vector<Rock>::iterator RockIt;
+
 inline float mass(Rock& rock) {
 	return rock.shape.radius * ROCK_RADIUS_MASS_RATIO;
 }
 
-float getTimeDeltaForRock(Rock& rock, float deltaTime);
 void updateRocks(Stage& stage, float deltaTime);
 uint8_t createRock(Stage& stage, Vector2 position, float radius, RockType type);
-int deleteRockByIdx(Stage& stage, int rock_idx);
-int deleteRockById(Stage& stage, uint8_t rock_id);
-Rock& findRock(Stage& stage, uint8_t rock_id);
-int findRockAtPosition(const Stage& stage, Vector2 position);
+RockIt deleteRock(Stage& stage, RockIt rockIt);
+RockIt deleteRock(Stage* stage, uint8_t rockId);
+RockIt findRock(Stage& stage, uint8_t rock_id);
+RockIt findRockAtPosition(Stage& stage, Vector2 position);
 void resizeRock(Stage& stage, int rockId, Vector2 position);
 
 inline float area(const Rock& rock) {

--- a/src/rock.hpp
+++ b/src/rock.hpp
@@ -7,6 +7,7 @@
 #include "constants.hpp"
 #include "maths.hpp"
 #include "prelude.hpp"
+#include "typedefs.hpp"
 #include "util.hpp"
 
 
@@ -20,7 +21,7 @@ struct RockState {
 		float timeFloating = 0.f;
 	};
 
-	enum StateType : uint8_t {
+	enum StateType : uint8 {
 		FALLING = 1 << 0,
 		STANDING = 1 << 1,
 		FLOATING = 1 << 2,
@@ -58,7 +59,7 @@ struct Rock {
 	RockType type;
 	bool active = false;
 	bool sized = false;
-	uint8_t id = 0;
+	uint8 id = 0;
 };
 
 typedef std::vector<Rock>::iterator RockIt;
@@ -68,10 +69,10 @@ inline float mass(Rock& rock) {
 }
 
 void updateRocks(Stage& stage, float deltaTime);
-uint8_t createRock(Stage& stage, Vector2 position, float radius, RockType type);
+uint8 createRock(Stage& stage, Vector2 position, float radius, RockType type);
 RockIt deleteRock(Stage& stage, RockIt rockIt);
-RockIt deleteRock(Stage* stage, uint8_t rockId);
-RockIt findRock(Stage& stage, uint8_t rock_id);
+RockIt deleteRock(Stage& stage, uint8 rockId);
+RockIt findRock(Stage& stage, uint8 rock_id);
 RockIt findRockAtPosition(Stage& stage, Vector2 position);
 void resizeRock(Stage& stage, int rockId, Vector2 position);
 

--- a/src/sea.cpp
+++ b/src/sea.cpp
@@ -6,19 +6,16 @@ uint8_t Sea::id_src = 0;
 
 float heightAtX(const Sea& sea, float x) {
 	float height = sea.level;
-	for (int i = 0; i < sea.numWaves; ++i) {
-		height += heightAtX(sea.waves[i], x);
+	for (const Wave& wave : sea.waves) {
+		height += wave.heightAtX(x);
 	}
 	return height;
 }
 
 Vector2 velocityAtX(const Sea& sea, float x) {
 	Vector2 velocity = VECTOR2_ZERO;
-	for (int i = 0 ; i < sea.numWaves; ++i) {
-		velocity += velocityAtX(sea.waves[i], x);
-		// if (squaredMagnitude(velocity) > 0) {
-		// 	return velocity; // return the first wave to give you a velocity
-		// }
+	for (const Wave& wave : sea.waves) {
+		velocity += wave.velocityAtX(x);
 	}
 	return velocity;
 }

--- a/src/sea.hpp
+++ b/src/sea.hpp
@@ -1,19 +1,21 @@
 #pragma once
 #include <algorithm>
-#include <cstdint>
+#include <vector>
 
 #include "aabb.hpp"
 #include "constants.hpp"
 #include "maths.hpp"
+#include "typedefs.hpp"
 #include "wave.hpp"
 
 
 struct Sea{
-	Wave waves[MAX_WAVES];
-	short numWaves = 0;
+	// Wave waves[MAX_WAVES];
+	// short numWaves = 0;
+	std::vector<Wave> waves;
 	float level = 0;
-	uint8_t id = 0;
-	static uint8_t id_src;
+	uint8 id = 0;
+	static uint8 id_src;
 };
 
 float heightAtX(const Sea& sea, float x); // return the y height of a sea at x

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -9,7 +9,7 @@ string serialize(const Stage& stage) {
 	stringstream stream;
 	stream << "{" <<
 		"\"sea_level\"" << ":" << stage.sea.level << "," <<
-		"\"platforms\"" << ":" << serialize(stage.platforms, stage.numPlatforms) << "," <<
+		"\"platforms\"" << ":" << serialize(stage.platforms) << "," <<
 		"\"ship\"" 		<< ":" << serialize(stage.ship.shape) << "," <<
 		"\"rock_spawn\""<< ":" << serialize(stage.rockSpawn) << "," <<
 		"\"win\""		<< ":" << serialize(stage.win) <<
@@ -17,12 +17,12 @@ string serialize(const Stage& stage) {
 	return stream.str();
 }
 
-std::string serialize(const Platform * platforms, const int numPlatforms) {
+std::string serialize(const std::vector<Platform> platforms) {
 	stringstream stream;
 	stream << "[";
-	for (int i = 0 ; i < numPlatforms; ++i) {
+	for (int i = 0 ; i < platforms.size(); ++i) {
 		stream << serialize(platforms[i].shape);
-		if ( i < numPlatforms - 1) { stream << ","; }
+		if ( i < platforms.size() - 1) { stream << ","; }
 	}
 	stream << "]";
 	return stream.str();

--- a/src/serialize.hpp
+++ b/src/serialize.hpp
@@ -8,7 +8,7 @@
 
 // Serialize
 std::string serialize(const Stage& stage);
-std::string serialize(const Platform * platforms, const int numPlatforms);
+std::string serialize(const std::vector<Platform> platforms);
 std::string serialize(const Rectangle& rectangle);
 std::string serialize(const Vector2 v);
 std::string serialize(const Win w);

--- a/src/ship.cpp
+++ b/src/ship.cpp
@@ -49,7 +49,7 @@ inline void updateStandingShip(Stage& stage, float deltaTime) {
 
 inline void updateSurfingShip(Stage& stage, Ship& ship) {
 	// TODO: Keep the ship on the crest of the wave
-	Wave & wave = findWave(stage.sea, ship.state.surfing.wave_id);
+	Wave & wave = *findWave(stage.sea, ship.state.surfing.wave_id);
 	ship.velocity.x = wave.velocity.x;
 	updateFallingShip(ship); // do all the same things you do for a falling ship
 	// ship.shape.position.x = wave.position.x;

--- a/src/stage.cpp
+++ b/src/stage.cpp
@@ -15,6 +15,7 @@
 
 
 void update(Stage& stage, float deltaTime){
+	assert(stage.id_src < (uint8)(-1)); // 255
 	switch(stage.state.type) {
 		case StageState::PAUSED:
 			stage.state.paused.time += deltaTime;
@@ -36,7 +37,6 @@ void update(Stage& stage, float deltaTime){
 		stage.state.finished.win = true;
 	}
 }
-
 
 Entity makeSelectionAtPosition(Stage& stage, Vector2 position) {
 	// For now we only select rocks so let's find our rock

--- a/src/stage.hpp
+++ b/src/stage.hpp
@@ -53,14 +53,14 @@ struct Stage{
 	Sea sea;
 	Ship ship;
 	std::vector<Rock> rocks;
-	Platform platforms[MAX_PLATFORMS];
+	std::vector<Platform> platforms;
+	// Platform platforms[MAX_PLATFORMS];
 	AABB aabbs[MAX_AABBS];
 	Vector2 rockSpawn;
 	Selection selection;
 	Win win;
 	StageState state;
 	uint8_t id_src = 0;
-	int numPlatforms = 0;
 	int numAABBS = 0;
 	RockType rockType = {RockType::RED};
 };

--- a/src/stage.hpp
+++ b/src/stage.hpp
@@ -9,9 +9,10 @@
 #include "rock.hpp"
 #include "sea.hpp"
 #include "ship.hpp"
+#include "typedefs.hpp"
 
 struct Selection {
-	enum State : uint8_t {
+	enum State : uint8 {
 		SELECT		= 1 << 0,
 		PULL 		= 1 << 2,
 	};
@@ -32,7 +33,7 @@ struct StageState {
 	struct Finished {
 		bool win = false;
 	};
-	enum StateType : uint8_t {
+	enum StateType : uint8 {
 		PAUSED = 1 << 0,
 		RUNNING = 1 << 1,
 		FINISHED = 1 << 2,
@@ -54,14 +55,12 @@ struct Stage{
 	Ship ship;
 	std::vector<Rock> rocks;
 	std::vector<Platform> platforms;
-	// Platform platforms[MAX_PLATFORMS];
-	AABB aabbs[MAX_AABBS];
+	std::vector<AABB> aabbs;	
 	Vector2 rockSpawn;
 	Selection selection;
 	Win win;
 	StageState state;
-	uint8_t id_src = 0;
-	int numAABBS = 0;
+	uint8 id_src = 0;
 	RockType rockType = {RockType::RED};
 };
 

--- a/src/stage.hpp
+++ b/src/stage.hpp
@@ -52,7 +52,7 @@ struct Win {
 struct Stage{
 	Sea sea;
 	Ship ship;
-	Rock rocks[MAX_ROCKS];
+	std::vector<Rock> rocks;
 	Platform platforms[MAX_PLATFORMS];
 	AABB aabbs[MAX_AABBS];
 	Vector2 rockSpawn;
@@ -60,7 +60,6 @@ struct Stage{
 	Win win;
 	StageState state;
 	uint8_t id_src = 0;
-	int numRocks = 0;
 	int numPlatforms = 0;
 	int numAABBS = 0;
 	RockType rockType = {RockType::RED};

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -101,46 +101,46 @@ void test_deserializer() {
 }
 
 void test_utils() {
- 	int blah [10] =  {};
-	int blah_size = 0;
-	std::cout << "Empty" << std::endl;
-	print_array(blah, blah_size);
-
-	std::cout << "Inserting" << std::endl;
-	sorted_insert(1, blah, blah_size);
-	print_array(blah, blah_size);
-
-	sorted_insert(2, blah, blah_size);
-	print_array(blah, blah_size);
-
-
-	sorted_insert(8, blah, blah_size);
-	print_array(blah, blah_size);
-
-	sorted_insert(6, blah, blah_size);
-	print_array(blah, blah_size);
-
-	sorted_insert(3, blah, blah_size);
-	print_array(blah, blah_size);
-
-	std::cout << "Pre-sort" << std::endl;
-	print_array(blah, blah_size);
- 	insertion_sort(blah, blah_size);
-	std::cout << "Post-sort" << std::endl;
-	print_array(blah, blah_size);
-	sorted_insert(4, blah, blah_size);
-	std::cout << "Insert 4" << std::endl;
-	print_array(blah, blah_size);
-	std::cout << "4 is at index: ";
-	std::cout << binary_find_where(4, blah, blah_size, [] (int a) { return a; });
-	std::cout << std::endl;
-	std::cout << "10 is at index: ";
-	std::cout << binary_find_where(10, blah, blah_size, [] (int a) { return a; });
-	std::cout << std::endl;
-	std::cout << "1 is at index: ";
-	std::cout << binary_find_where(1, blah, blah_size, [] (int a) { return a; });
-	std::cout << std::endl;
-	std::cout << "6 is at index: ";
-	std::cout << binary_find_where(6, blah, blah_size, [] (int a) { return a; });
-	std::cout << std::endl;
+//  	int blah [10] =  {};
+// 	int blah_size = 0;
+// 	std::cout << "Empty" << std::endl;
+// 	print_array(blah, blah_size);
+// 
+// 	std::cout << "Inserting" << std::endl;
+// 	sorted_insert(1, blah, blah_size);
+// 	print_array(blah, blah_size);
+// 
+// 	sorted_insert(2, blah, blah_size);
+// 	print_array(blah, blah_size);
+// 
+// 
+// 	sorted_insert(8, blah, blah_size);
+// 	print_array(blah, blah_size);
+// 
+// 	sorted_insert(6, blah, blah_size);
+// 	print_array(blah, blah_size);
+// 
+// 	sorted_insert(3, blah, blah_size);
+// 	print_array(blah, blah_size);
+// 
+// 	std::cout << "Pre-sort" << std::endl;
+// 	print_array(blah, blah_size);
+//  	insertion_sort(blah, blah_size);
+// 	std::cout << "Post-sort" << std::endl;
+// 	print_array(blah, blah_size);
+// 	sorted_insert(4, blah, blah_size);
+// 	std::cout << "Insert 4" << std::endl;
+// 	print_array(blah, blah_size);
+// 	std::cout << "4 is at index: ";
+// 	std::cout << binary_find_where(4, blah, blah_size, [] (int a) { return a; });
+// 	std::cout << std::endl;
+// 	std::cout << "10 is at index: ";
+// 	std::cout << binary_find_where(10, blah, blah_size, [] (int a) { return a; });
+// 	std::cout << std::endl;
+// 	std::cout << "1 is at index: ";
+// 	std::cout << binary_find_where(1, blah, blah_size, [] (int a) { return a; });
+// 	std::cout << std::endl;
+// 	std::cout << "6 is at index: ";
+// 	std::cout << binary_find_where(6, blah, blah_size, [] (int a) { return a; });
+// 	std::cout << std::endl;
 }

--- a/src/typedefs.hpp
+++ b/src/typedefs.hpp
@@ -1,0 +1,4 @@
+#include <cstdint>
+
+typedef uint8_t uint8;
+typedef int8_t int8;

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -8,6 +8,20 @@
 /**************
  * Algorithms *
  **************/
+template <typename T, typename Iter, typename Pred>
+void insertion_sort(Iter begin, Iter end, Pred predicate) {
+	for (auto it = begin; it != end; ++it) {
+		std::rotate(std::upper_bound(begin, it, *it, predicate), it, std::next(it));
+	}
+}
+
+template <typename T, typename It, typename Pred>
+typename std::vector<T>::iterator sorted_insert(std::vector<T>& v, T item, Pred predicate) {
+	return v.insert(
+		std::upper_bound<It, T>(v.begin(), v.end(), item, predicate),
+		item
+	);
+}
 
 template<typename T, typename Pred>
 inline void insertion_sort(T* t, const int count, Pred predicate) {
@@ -25,40 +39,40 @@ inline void insertion_sort(T* t, const int count) {
 	return insertion_sort(t, count, [](T a, T b) { return a<b; });
 }
 
-template <typename T, typename Pred>
-inline void sorted_insert(T t_item, T* t, int & count, Pred predicate) {
-	if (count == 0) {
-		t[0] = t_item;
-		++count;
-		return;
-	}
-	for(int i = 0; i<count; ++i){
-		if(predicate(t[i],t_item)) {
-			if (i == count - 1) { // at the end of array
-				t[i+1] = t_item;
-				++count;
-				return;
-			}
-			continue;
-		} else {
-			T swap;
-			swap = t[i];
-			t[i] = t_item;
-			for (int j = i+1; j<count+1; ++j){
-				T swap_swap = swap;
-				swap = t[j];
-				t[j] = swap_swap;
-			}
-			++count;
-			break;
-		}
-	}
-}
+// template <typename T, typename Pred>
+// inline void sorted_insert(T t_item, T* t, int & count, Pred predicate) {
+// 	if (count == 0) {
+// 		t[0] = t_item;
+// 		++count;
+// 		return;
+// 	}
+// 	for(int i = 0; i<count; ++i){
+// 		if(predicate(t[i],t_item)) {
+// 			if (i == count - 1) { // at the end of array
+// 				t[i+1] = t_item;
+// 				++count;
+// 				return;
+// 			}
+// 			continue;
+// 		} else {
+// 			T swap;
+// 			swap = t[i];
+// 			t[i] = t_item;
+// 			for (int j = i+1; j<count+1; ++j){
+// 				T swap_swap = swap;
+// 				swap = t[j];
+// 				t[j] = swap_swap;
+// 			}
+// 			++count;
+// 			break;
+// 		}
+// 	}
+// }
 
-template <typename T>
-inline void sorted_insert(T t_item, T* t, int & count) {
-	return sorted_insert(t_item, t, count, [](T a, T b) { return a<b; });
-}
+// template <typename T>
+// inline void sorted_insert(T t_item, T* t, int & count) {
+// 	return sorted_insert(t_item, t, count, [](T a, T b) { return a<b; });
+// }
 
 template <typename T, typename BinaryPred>
 inline int find_where(const T t_item, const T* const t, const int count, BinaryPred predicate) {

--- a/src/wave.hpp
+++ b/src/wave.hpp
@@ -1,35 +1,42 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
+
 #include "aabb.hpp"
 #include "constants.hpp"
 #include "prelude.hpp"
 #include "maths.hpp"
+#include "typedefs.hpp"
 #include "util.hpp"
 
 
 struct Wave {
-	inline Wave() {}
 	Vector2 position = {0.f, 0.f};
 	Vector2 velocity = {0.f, 0.f};
 	float amplitude = 0.f;
 	float decay = 0.f;
 	float time = 0.f;
-	short direction = 1;
-	short sign = 1;
+	int8 direction = 1;
+	int8 sign = 1;
 	bool active = false;
 	bool grow = true;
-	uint8_t id = 0;
+	uint8 id = 0;
+
+	inline float heightAtX(float x) const;
+	inline Vector2 velocityAtX(float x) const;
+	inline float slopeAtX(float x) const; // derivative of height
+	inline float minimumX() const;
+	inline float maximumX() const;
 };
 
-float heightAtX(const Wave& wave, float x);
-Vector2 velocityAtX(const Wave& wave, float x);
-float slopeAtX(const Wave & wave, float x); // derivative of height
-float minimumX(const Wave& wave);
-float maximumX(const Wave& wave);
+#include "wave.inl"
+
+typedef std::vector<Wave>::iterator WaveIt;
 
 void updateWaves(Stage& stage);
-int createWave(Sea& sea, Vector2 position, float amplitude, short direction, short sign);
-
-int findWaveAtX(const Sea& sea, float x);
-Wave& findWave(Sea& sea, uint8_t wave_id);
+uint8 createWave(Sea& sea, Vector2 position, float amplitude, int direction, int sign);
+WaveIt deleteWave(Sea& sea, WaveIt waveIt);
+WaveIt deleteWave(Sea& sea, uint8 waveId);
+WaveIt findWave(Sea& sea, uint8 waveId);
+WaveIt findWaveAtPosition(Sea& sea, Vector2 position);

--- a/src/wave.inl
+++ b/src/wave.inl
@@ -1,0 +1,37 @@
+// wave.hpp
+
+inline float Wave::heightAtX(float x) const {
+	// get the height of the wave at x
+	// Cool gaussian
+	return signOf(sign) * amplitude * decay * pow(E, -pow(WAVE_WIDTH_MULTIPLIER * (x - position.x), 2));
+}
+
+inline Vector2 Wave::velocityAtX(float x) const {
+	float distFromMid = x - position.x;
+	if(distFromMid < 0) {
+		return VECTOR2_ZERO; // Don't do anything on the back of a wave
+	} else if (distFromMid == 0) {
+		return velocity; // if you're at the middle of the wave get the full velocity
+	} else { // else get the velocity as a ratio of your distance the center
+		float max = maximumX();
+		if (max < x) { return VECTOR2_ZERO; }
+		float min = minimumX();
+		float halfLength = (max - min)/2.f;
+		return ((halfLength - distFromMid)/halfLength) * velocity;
+	}
+}
+
+inline float Wave::slopeAtX(float x) const {
+	// derivative of height
+	return heightAtX(x) * (-2 * WAVE_WIDTH_MULTIPLIER * (x - position.x) * WAVE_WIDTH_MULTIPLIER);
+}
+
+inline float Wave::minimumX() const {
+	return position.x - 2.5f * (1 / WAVE_WIDTH_MULTIPLIER); // solve for heightAtX == 0
+}
+
+inline float Wave::maximumX() const {
+	return position.x + 2.5f * (1 / WAVE_WIDTH_MULTIPLIER);
+}
+
+


### PR DESCRIPTION
I initially used static arrays to avoid memory fragmentation (vectors allocate on the heap) but I think that was a mis-step. Luckily when I made that call I didn't make it impossible to cut over to vectors.  This PR isn't ready yet. Still need to get a few more things off arrays 