### PR TITLE
Put shapes in namespace

### DIFF
--- a/src/collision.cpp
+++ b/src/collision.cpp
@@ -11,8 +11,11 @@
 #include "platform.hpp"
 #include "printing.hpp"
 #include "rock.hpp"
+#include "shapes.hpp"
 #include "stage.hpp"
 #include "util.hpp"
+
+using namespace wabi;
 
 void resolveCollisions(Stage& stage) {
 	// NOTE (owen): if it starts to get slow this is definately a place we can optimize
@@ -186,7 +189,7 @@ inline void collideGreen(Rock& rock, Sea& sea) {
 	rock.velocity += drag * FIXED_TIMESTEP;
 
 	if(rock.state.type != RockState::FLOATING) {
-		rock.state = {RockState::FLOATING, {0.f}};
+		rock.state = {RockState::FLOATING, {{0.f}}};
 	}
 	if (sea.waves.size() < 0) { return; } // nothing to do for no waves
 	WaveIt closestWaveIt = findWaveAtPosition(sea, rock.shape.position);

--- a/src/collision.hpp
+++ b/src/collision.hpp
@@ -3,6 +3,7 @@
 
 #include "aabb.hpp"
 #include "prelude.hpp"
+#include "shapes.hpp"
 #include "util.hpp"
 
 void resolveCollisions(Stage& stage);
@@ -37,9 +38,9 @@ struct Collision {
 };
 
 template <int N, int M>
-Collision collision(const Polygon<N>& poly1, const Polygon<M>& poly2);
+Collision collision(const wabi::Polygon<N>& poly1, const wabi::Polygon<M>& poly2);
 template <int N>
-Collision collision(const Circle& circle, const Polygon<N>& polygon);
-Collision collision(const Circle& c1, const Circle& c2);
+Collision collision(const wabi::Circle& circle, const wabi::Polygon<N>& polygon);
+Collision collision(const wabi::Circle& c1, const wabi::Circle& c2);
 
 #include "collision.inl"

--- a/src/collision.inl
+++ b/src/collision.inl
@@ -4,7 +4,7 @@
 // NOTE: this only determines if poly1 is specifically overlaping poly2
 // Also NOTE: poly1 and poly2 must be CONVEX
 template <int N, int M>
-Collision collision(const Polygon<N>& poly1, const Polygon<M>& poly2) {
+Collision collision(const wabi::Polygon<N>& poly1, const wabi::Polygon<M>& poly2) {
 	// check the diagonals of one polygon ...
 	std::vector<Collision> collisions;
 	for (int i = 0; i < poly1.size; ++i) {
@@ -42,7 +42,7 @@ Collision collision(const Polygon<N>& poly1, const Polygon<M>& poly2) {
 }
 
 template <int N>
-Collision collision(const Circle& circle, const Polygon<N>& polygon) {
+Collision collision(const wabi::Circle& circle, const wabi::Polygon<N>& polygon) {
 	std::vector<Collision> collisions;
 	// Start with the circle position
 	Vector2 c = circle.position;

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -16,6 +16,9 @@ inline void loadStage(Game& game) {
 	if (loadStageFromFile("assets/levels/level1.json", game.stage, e)) {
 		game.stage.state.type = StageState::RUNNING;
 		createAABB(game.stage, AABB(game.stage.sea)); // TODO: make seas a list so there can be seas anywhere
+		return;
+	} else {
+		throw e;
 	}
 }
 

--- a/src/game.cxx
+++ b/src/game.cxx
@@ -5,9 +5,11 @@
 #include "printing.hpp"
 #include "graphics.hpp"
 #include "serialize.hpp"
+#include "win32_file.hpp"
 
 
 int main() {
+	std::cout << ExePath() << std::endl;
 	sf::RenderWindow window;
 	sf::ContextSettings settings;
 	// sf::VideoMode videoMode = sf::VideoMode::getDesktopMode();
@@ -20,28 +22,33 @@ int main() {
 	 	std::cout << "Couldn't load font" << std::endl;
 	}
 
-	Clock drawClock;
-	Game game;
-	start(game);
-	while(!game.end && window.isOpen()) {
-		sf::Event e;
-		while(window.pollEvent(e)) {
-			processEvent(game, e, window);
-			if(e.type == sf::Event::Resized) {
-				auto view = window.getView();
-				view.setCenter({e.size.width/2.f, e.size.height/2.f});
-				view.setSize({(float)e.size.width, (float)e.size.height});
-				window.setView(view);
+	try {
+		Clock drawClock;
+		Game game;
+		start(game);
+		while(!game.end && window.isOpen()) {
+			sf::Event e;
+			while(window.pollEvent(e)) {
+				processEvent(game, e, window);
+				if(e.type == sf::Event::Resized) {
+					auto view = window.getView();
+					view.setCenter({e.size.width/2.f, e.size.height/2.f});
+					view.setSize({(float)e.size.width, (float)e.size.height});
+					window.setView(view);
+				}
+			}
+			update(game);
+			float drawDelta = drawClock.getElapsedTime().asSeconds();
+			if (drawDelta >= FRAME_RATE) {
+				drawStage(window, game.stage, true);
+				drawInfoText(window, game.stage, drawDelta, game.updateDelta, 0);
+				window.display();
+				drawClock.restart();
 			}
 		}
-		update(game);
-		float drawDelta = drawClock.getElapsedTime().asSeconds();
-		if (drawDelta >= FRAME_RATE) {
-			drawStage(window, game.stage, true);
-			drawInfoText(window, game.stage, drawDelta, game.updateDelta, 0);
-			window.display();
-			drawClock.restart();
-		}
+		stop(game);
+	} catch (SerializeError & e) {
+		std::cout << e.what << std::endl;
+		return 1;
 	}
-	stop(game);
 }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -19,6 +19,8 @@
 
 sf::Font font;
 
+using namespace wabi;
+
 void initGraphics() {
 	if (!font.loadFromFile("assets/fonts/IBMPlexMono-Regular.ttf")){
 	 	std::cout << "Couldn't load font" << std::endl;
@@ -49,7 +51,7 @@ void drawStage(sf::RenderTarget& target, Stage& stage,  bool showGrid) {
 	drawPullParabola(target, stage);
 	for (AABB aabb : stage.aabbs) {
 		Vector2 diff = aabb.upper - aabb.lower;
-		Vector2 pos = { aabb.lower.x + 0.5 * diff.x, aabb.lower.y + 0.5 * diff.y };
+		Vector2 pos = { aabb.lower.x + 0.5f * diff.x, aabb.lower.y + 0.5f * diff.y };
 		drawPolygon(target, makeRectangle(pos, diff.x, diff.y), sf::Color::Yellow);
 	}
 }

--- a/src/graphics.hpp
+++ b/src/graphics.hpp
@@ -7,6 +7,7 @@
 #include "clock.hpp"
 #include "maths.hpp"
 #include "rock.hpp"
+#include "shapes.hpp"
 #include "sea.hpp"
 
 #define SEA_COLOR sf::Color::Cyan
@@ -28,11 +29,11 @@ inline void drawGrid(sf::RenderTarget&);
 void drawInfoText(sf::RenderTarget&, const Stage& , float, float, int);
 
 template <int N>
-inline void drawPolygon(sf::RenderTarget&, const Polygon<N>&, sf::Color);
+inline void drawPolygon(sf::RenderTarget&, const wabi::Polygon<N>&, sf::Color);
 inline void drawText(sf::RenderTarget&, std::string, sf::Vector2f, int=15, bool=false);
 inline void drawId(sf::RenderTarget&, int, sf::Vector2f);
 inline void drawId(sf::RenderTarget&, int, Vector2);
-inline void drawCircle(sf::RenderTarget&, const Circle&, sf::Color, bool fill=false);
+inline void drawCircle(sf::RenderTarget&, const wabi::Circle&, sf::Color, bool fill=false);
 inline void drawLine(sf::RenderTarget&, Vector2, Vector2, sf::Color);
 
 inline sf::Vector2f game2ScreenPos(const sf::RenderTarget&, Vector2);
@@ -40,7 +41,7 @@ inline Vector2 screen2GamePos(const sf::RenderTarget&, sf::Vector2i);
 float ppu(sf::RenderTarget&);
 
 template <int N>
-void drawPolygon(sf::RenderTarget& target, const Polygon<N>& polygon, sf::Color c) {
+void drawPolygon(sf::RenderTarget& target, const wabi::Polygon<N>& polygon, sf::Color c) {
 	sf::VertexArray sfVertices(sf::LineStrip, N+1);
 	for (int i = 0; i < N; ++i) {
 		sfVertices[i] = sf::Vertex(game2ScreenPos(target, polygon.vertices[i]), c);

--- a/src/maths.cpp
+++ b/src/maths.cpp
@@ -1,29 +1,5 @@
 #include "maths.hpp"
 
-/***************
- * Shape Stuff *
- ***************/
-
-Rectangle makeRectangle(Vector2 p, float w, float h, float rotation) {
-	Rectangle r;
-	r.width = w;
-	r.height = h;
-	r.position = p;
-	r.rotation = rotation;
-	float halfWidth = w/2.f;
-	float halfHeight = h/2.f;
-	r.model[0] = {-halfWidth, halfHeight}; // top left
-	r.model[1] = {halfWidth, halfHeight}; // top right
-	r.model[2] = {halfWidth, -halfHeight}; // bottom right
-	r.model[3] = {-halfWidth, -halfHeight}; // bottom left
-	r.vertices[0] = r.position + r.model[0];
-	r.vertices[1] = r.position + r.model[1];
-	r.vertices[2] = r.position + r.model[2];
-	r.vertices[3] = r.position + r.model[3];
-	return r;
-}
-
-
 /******************
  * Geometry Stuff *
  ******************/

--- a/src/maths.hpp
+++ b/src/maths.hpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <vector>
 
+#include "vector2.hpp"
+
 /********
  * Misc *
  ********/
@@ -18,105 +20,6 @@ T signOf(T t) {
 	return sign<T>(t);
 }
 
-
-/***********
- * Vectors *
- ***********/
-
-struct Vector2{
-	float& operator[](int i) { return (&x)[i]; } // read
-	const float& operator[](int i) const { return (&x)[i]; }; // write
-	float x = 0.f, y = 0.f;
-};
-
-const Vector2 VECTOR2_UP {0.f, 1.f};
-const Vector2 VECTOR2_DOWN {0.f, -1.f};
-const Vector2 VECTOR2_LEFT {-1.f, 0.f};
-const Vector2 VECTOR2_RIGHT {1.f, 0.f};
-const Vector2 VECTOR2_ZERO {0.f, 0.f};
-
-// Vector negation
-inline Vector2 operator-(const Vector2& v);
-// Vector/Vector addition and subtraction
-inline Vector2 operator+(const Vector2& b, const Vector2& a);
-inline Vector2 operator-(const Vector2& a, const Vector2& b);
-inline Vector2& operator+=(Vector2& a, const Vector2& b);
-inline Vector2& operator-=(Vector2& a, const Vector2& b);
-// Vector equality an inequality
-inline bool operator==(const Vector2& a, const Vector2& b);
-inline bool operator!=(const Vector2& a, const Vector2& b);
-// Vector/Scalar multiplication and addition
-inline Vector2 operator*(const Vector2& v, float s);
-inline Vector2 operator*(float s, const Vector2& v);
-inline Vector2 operator/(const Vector2& v, float s);
-inline Vector2 operator/(float s, const Vector2& v);
-inline Vector2& operator*=(Vector2& v, float s);
-inline Vector2& operator/=(Vector2& v, float s);
-// Vector math operations
-inline float dot(const Vector2& a, const Vector2& b);
-inline float cross(const Vector2& a, const Vector2& b);
-inline float squaredMagnitude(const Vector2& v);
-inline float magnitude(const Vector2& v);
-// normalize copy
-inline Vector2 normalized(const Vector2& v);
-// normalize in place
-inline Vector2& normalize(Vector2& v);
-inline Vector2& clamp(Vector2& v, float s); // clamp this vector to a scalar magnitude
-// returns + if point on left - if point on right 0 if point on line from b to a
-inline float sideSign(Vector2 a, Vector2 b, Vector2 point);
-// returns true if point is bounded on the line segment defined by a and b
-inline bool bounded(Vector2 a, Vector2 b, Vector2 point);
-
-#include "vector2.inl" // definitions for template functions and inlines
-
-/**********
- * Shapes *
- **********/
-
-struct Circle {
-	Vector2 position;
-	float radius = 0.f;
-};
-
-// NOTE: Polygon vertices in the array in order from top left to topleft clockwise
-// example:
-//      index 0					index 1
-//      	*---------------------*
-//      	|                     |
-//      	*---------------------*
-//      index 3					 index 2
-template <int N>
-struct Polygon {
-	Vector2 position;
-	Vector2 vertices[N];
-	Vector2 model[N];
-	int size = N;
-	float rotation = 0.f;
-};
-
-struct Rectangle : Polygon<4>{
-	float width = 0.f;
-	float height = 0.f;
-};
-
-inline float area(const Circle & circle);
-inline float area(Rectangle& rectangle);
-template <int N>
-inline void updateVertices(Polygon<N>& polygon);
-template <int N>
-inline bool pointInsidePolygon(Vector2 point, Polygon<N>& polygon);
-template <int N>
-inline Vector2 lower(const Polygon<N>& polygon); // gets the bottom left point of a polygon in relation to x, y axis
-template <int N>
-inline Vector2 upper(const Polygon<N>& polygon); // gets the top right point of a polygon in raltion to x, y axis
-template <int N>
-inline void boundingPoints(const Polygon<N>& polygon, Vector2& lower, Vector2& upper);
-
-
-#include "shapes.inl" // definitions for template functions and inlines
-
-Rectangle makeRectangle(Vector2 p, float w, float h, float rotation=0.f);
-
 /************
  * Geometry *
  ************/
@@ -124,3 +27,30 @@ Rectangle makeRectangle(Vector2 p, float w, float h, float rotation=0.f);
 bool lineSegmentIntersection(Vector2 a, Vector2 b, Vector2 c, Vector2 d, Vector2& intersection);
 Vector2 findNormal(Vector2 a, Vector2 b, Vector2 c);
 
+// returns + if point on left - if point on right 0 if point on line from b to a
+inline float sideSign(Vector2 a, Vector2 b, Vector2 point) {
+	Vector2 u = b - a;
+	Vector2 v = point - a;
+	float product = cross(u, v);
+	return sign(product);
+}
+
+inline bool bounded(Vector2 a, Vector2 b, Vector2 point) {
+	Vector2 ba = b - a;
+	if (std::abs(ba.x) > std::abs(ba.y)) { // line more horizontally oriented
+		// we check that we are bounded on x
+		if (ba.x > 0) { // positive dx means b.x > a.x
+			return point.x >= a.x && point.x <=b.x;
+		} else { // negative dx means that b.x < a.x
+			return point.x >= b.x && point.x <=a.x;
+		}
+	} else { // line is more vertically oriented
+		// we check that we are bounded on y
+		if (ba.y > 0) { // positive dy means b.y > a.y
+			return point.y >= a.y && point.y <= b.y;
+		} else { // negative dy means that a.y > b.y
+			return point.y >= b.y && point.y <= a.y;
+		}
+	}
+	assert(false);
+}

--- a/src/platform.cpp
+++ b/src/platform.cpp
@@ -2,6 +2,8 @@
 #include "platform.hpp"
 #include "stage.hpp"
 
+using namespace wabi;
+
 uint8 createPlatform(Stage& stage, Vector2 position, float width, float height) {
 	Platform platform;
 	platform.shape = makeRectangle(position, width, height);
@@ -22,6 +24,6 @@ uint8 createPlatform(Stage& stage, Rectangle rect) {
 
 PlatformIt findPlatform(Stage& stage, uint8 platformId) {
 	PlatformIt platformIt = std::lower_bound(stage.platforms.begin(), stage.platforms.end(), platformId, [](Platform& p, uint8 id) -> bool { return p.id < id; });
-	assert(platformIt != stage.platforms.end()); // ... then this assertion will fail ...
+	assert(platformIt != stage.platforms.end());
 	return platformIt;
 }

--- a/src/platform.hpp
+++ b/src/platform.hpp
@@ -2,18 +2,19 @@
 #include "aabb.hpp"
 #include "constants.hpp"
 #include "maths.hpp"
+#include "shapes.hpp"
 #include "typedefs.hpp"
 #include "util.hpp"
 
 struct Platform {
-	Rectangle shape;
+	wabi::Rectangle shape;
 	uint8 id = 0;
 };
 
 typedef std::vector<Platform>::iterator PlatformIt;
 
 uint8 createPlatform(Stage& stage, Vector2 position, float width, float height);
-uint8 createPlatform(Stage& stage, Rectangle);
+uint8 createPlatform(Stage& stage, wabi::Rectangle);
 PlatformIt findPlatform(Stage& stage, uint8 platform_id);
 
 inline float mass(const Platform& platform) {

--- a/src/printing.hpp
+++ b/src/printing.hpp
@@ -29,4 +29,3 @@ std::ostream& operator<<(std::ostream& os, AABB aabb);
 std::ostream& operator<<(std::ostream& os, sf::Vector2f v);
 
 
-

--- a/src/rock.hpp
+++ b/src/rock.hpp
@@ -7,6 +7,7 @@
 #include "constants.hpp"
 #include "maths.hpp"
 #include "prelude.hpp"
+#include "shapes.hpp"
 #include "typedefs.hpp"
 #include "util.hpp"
 
@@ -53,7 +54,7 @@ struct RockType {
 
 
 struct Rock {
-	Circle shape = {{0.f, 0.f}, 0.f};
+	wabi::Circle shape = {{0.f, 0.f}, 0.f};
 	Vector2 velocity = {0.f, 0.f};
 	RockState state { RockState::FALLING, {} };
 	RockType type;

--- a/src/serialize.cpp
+++ b/src/serialize.cpp
@@ -4,6 +4,7 @@
 #include "json.hpp"
 
 using namespace std;
+using namespace wabi;
 
 string serialize(const Stage& stage) {
 	stringstream stream;

--- a/src/serialize.hpp
+++ b/src/serialize.hpp
@@ -3,13 +3,14 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include "shapes.hpp"
 #include "stage.hpp"
 #include "json.hpp"
 
 // Serialize
 std::string serialize(const Stage& stage);
 std::string serialize(const std::vector<Platform> platforms);
-std::string serialize(const Rectangle& rectangle);
+std::string serialize(const wabi::Rectangle& rectangle);
 std::string serialize(const Vector2 v);
 std::string serialize(const Win w);
 

--- a/src/shapes.cpp
+++ b/src/shapes.cpp
@@ -1,0 +1,25 @@
+#include "shapes.hpp"
+
+namespace wabi {
+
+Rectangle::Rectangle(Vector2 p, float w, float h, float r) : width(w), height(h) {
+	position = p;
+	rotation = r;
+	float halfWidth = w/2.f;
+	float halfHeight = h/2.f;
+	model[0] = {-halfWidth, halfHeight}; // top left
+	model[1] = {halfWidth, halfHeight}; // top right
+	model[2] = {halfWidth, -halfHeight}; // bottom right
+	model[3] = {-halfWidth, -halfHeight}; // bottom left
+	vertices[0] = position + model[0];
+	vertices[1] = position + model[1];
+	vertices[2] = position + model[2];
+	vertices[3] = position + model[3];
+
+}
+
+Rectangle makeRectangle(Vector2 p, float w, float h, float rotation) {
+	return Rectangle(p, w, h, rotation);
+}
+
+} // namespace wabi

--- a/src/shapes.hpp
+++ b/src/shapes.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include "maths.hpp"
+
+namespace wabi {
+
+/**********
+ * Shapes *
+ **********/
+
+struct Circle {
+	Vector2 position;
+	float radius = 0.f;
+};
+
+// NOTE: Polygon vertices in the array in order from top left to topleft clockwise
+// example:
+//      index 0					index 1
+//      	*---------------------*
+//      	|                     |
+//      	*---------------------*
+//      index 3					 index 2
+template <int N>
+struct Polygon {
+	Vector2 position;
+	Vector2 vertices[N];
+	Vector2 model[N];
+	int size = N;
+	float rotation = 0.f;
+};
+
+struct Rectangle : Polygon<4>{
+	Rectangle() {}
+	Rectangle(Vector2 p, float w, float h, float r=0.f);
+
+	float width = 0.f;
+	float height = 0.f;
+};
+
+inline float area(const Circle & circle);
+inline float area(Rectangle& rectangle);
+template <int N>
+inline void updateVertices(Polygon<N>& polygon);
+template <int N>
+inline bool pointInsidePolygon(Vector2 point, Polygon<N>& polygon);
+template <int N>
+inline Vector2 lower(const Polygon<N>& polygon); // gets the bottom left point of a polygon in relation to x, y axis
+template <int N>
+inline Vector2 upper(const Polygon<N>& polygon); // gets the top right point of a polygon in raltion to x, y axis
+template <int N>
+inline void boundingPoints(const Polygon<N>& polygon, Vector2& lower, Vector2& upper);
+
+
+Rectangle makeRectangle(Vector2 p, float w, float h, float rotation=0.f);
+
+} // namespace wabi
+
+#include "shapes.inl" // definitions for template functions and inlines

--- a/src/shapes.inl
+++ b/src/shapes.inl
@@ -1,7 +1,7 @@
-// maths.hpp
+// shapes.hpp
 
 #include "constants.hpp"
-
+namespace wabi {
 inline float area(const Circle& circle) {
 	return circle.radius * circle.radius * PI;
 }
@@ -74,3 +74,5 @@ inline void boundingPoints(const Polygon<N>& polygon, Vector2& lower, Vector2& u
 	lower = {minX, minY};
 	upper = {maxX, maxY};
 }
+
+} // namespace wabi

--- a/src/ship.cpp
+++ b/src/ship.cpp
@@ -5,6 +5,8 @@
 #include "ship.hpp"
 #include "stage.hpp"
 
+using namespace wabi;
+
 inline void updateFallingShip(Ship& ship) {
 	ship.velocity += GRAVITY * FIXED_TIMESTEP;
 	auto drag = dragForce(ship.velocity, 1.225f, mass(ship) * SHIP_AREA_MASS_RATIO);

--- a/src/ship.hpp
+++ b/src/ship.hpp
@@ -2,6 +2,7 @@
 
 #include "prelude.hpp"
 #include "maths.hpp"
+#include "shapes.hpp"
 
 struct ShipState {
 	struct FallingState { };
@@ -28,7 +29,7 @@ struct ShipState {
 };
 
 struct Ship {
-	Rectangle shape;
+	wabi::Rectangle shape;
 	Vector2 velocity;
 	ShipState state = {ShipState::FALLING, {}};
 	uint8_t id = 0;
@@ -41,6 +42,6 @@ inline float mass(const Ship& ship) {
 
 void updateShip(Stage& stage, float deltaTime);
 uint8_t createShip(Stage& stage, Vector2 position, float width, float height);
-uint8_t createShip(Stage& stage, Rectangle rect);
+uint8_t createShip(Stage& stage, wabi::Rectangle rect);
 
 

--- a/src/stage.hpp
+++ b/src/stage.hpp
@@ -8,6 +8,7 @@
 #include "platform.hpp"
 #include "rock.hpp"
 #include "sea.hpp"
+#include "shapes.hpp"
 #include "ship.hpp"
 #include "typedefs.hpp"
 
@@ -47,7 +48,7 @@ struct StageState {
 struct Win {
 	float timeInArea = 0;
 	float timeToWin = 0.25;
-	Rectangle region;
+	wabi::Rectangle region;
 };
 
 struct Stage{
@@ -57,7 +58,7 @@ struct Stage{
 	std::vector<Platform> platforms;
 
 	// TODO: move this ship to a struct just for collision stuff maybe? gonna make addressing it longer though
-	std::vector<AABB> aabbs;	
+	std::vector<AABB> aabbs;
 	std::vector<uint8> xAxisOrder;
 	std::vector<uint8> yAxisOrder;
 

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -15,15 +15,16 @@
 #include "maths.hpp"
 #include "printing.hpp"
 #include "serialize.hpp"
+#include "shapes.hpp"
 #include "stage.hpp"
 #include "test.hpp"
 #include "util.hpp"
 
-
+using namespace wabi;
 void test_shapes_and_shit(sf::RenderWindow& window) {
 	// Testing shapes and shit
-	Rectangle rectangle = makeRectangle({STAGE_WIDTH/2, STAGE_HEIGHT/2}, 30, 5);
-	Circle circle = {{STAGE_WIDTH/2-14, STAGE_HEIGHT/2 + 5}, 3.f};
+	wabi::Rectangle rectangle = wabi::makeRectangle({STAGE_WIDTH/2, STAGE_HEIGHT/2}, 30, 5);
+	wabi::Circle circle = {{STAGE_WIDTH/2-14, STAGE_HEIGHT/2 + 5}, 3.f};
 	Vector2 p1 = rectangle.position;
 	Vector2 p2 = rectangle.position - Vector2{rectangle.width, 0.f};
 	Vector2 p3 = rectangle.position - Vector2{rectangle.width/2.f, 0.f};

--- a/src/vector2.hpp
+++ b/src/vector2.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+/***********
+ * Vectors *
+ ***********/
+
+struct Vector2{
+	float& operator[](int i) { return (&x)[i]; } // read
+	const float& operator[](int i) const { return (&x)[i]; }; // write
+	float x = 0.f, y = 0.f;
+};
+
+const Vector2 VECTOR2_UP {0.f, 1.f};
+const Vector2 VECTOR2_DOWN {0.f, -1.f};
+const Vector2 VECTOR2_LEFT {-1.f, 0.f};
+const Vector2 VECTOR2_RIGHT {1.f, 0.f};
+const Vector2 VECTOR2_ZERO {0.f, 0.f};
+
+// Vector negation
+inline Vector2 operator-(const Vector2& v);
+// Vector/Vector addition and subtraction
+inline Vector2 operator+(const Vector2& b, const Vector2& a);
+inline Vector2 operator-(const Vector2& a, const Vector2& b);
+inline Vector2& operator+=(Vector2& a, const Vector2& b);
+inline Vector2& operator-=(Vector2& a, const Vector2& b);
+// Vector equality an inequality
+inline bool operator==(const Vector2& a, const Vector2& b);
+inline bool operator!=(const Vector2& a, const Vector2& b);
+// Vector/Scalar multiplication and addition
+inline Vector2 operator*(const Vector2& v, float s);
+inline Vector2 operator*(float s, const Vector2& v);
+inline Vector2 operator/(const Vector2& v, float s);
+inline Vector2 operator/(float s, const Vector2& v);
+inline Vector2& operator*=(Vector2& v, float s);
+inline Vector2& operator/=(Vector2& v, float s);
+// Vector math operations
+inline float dot(const Vector2& a, const Vector2& b);
+inline float cross(const Vector2& a, const Vector2& b);
+inline float squaredMagnitude(const Vector2& v);
+inline float magnitude(const Vector2& v);
+// normalize copy
+inline Vector2 normalized(const Vector2& v);
+// normalize in place
+inline Vector2& normalize(Vector2& v);
+inline Vector2& clamp(Vector2& v, float s); // clamp this vector to a scalar magnitude
+// returns + if point on left - if point on right 0 if point on line from b to a
+inline float sideSign(Vector2 a, Vector2 b, Vector2 point);
+// returns true if point is bounded on the line segment defined by a and b
+inline bool bounded(Vector2 a, Vector2 b, Vector2 point);
+
+#include "vector2.inl" // definitions for template functions and inlines
+
+

--- a/src/vector2.inl
+++ b/src/vector2.inl
@@ -125,31 +125,3 @@ inline Vector2& clamp(Vector2& v, float s) {
 	return v;
 }
 
-// returns + if point on left - if point on right 0 if point on line from b to a
-inline float sideSign(Vector2 a, Vector2 b, Vector2 point) {
-	Vector2 u = b - a;
-	Vector2 v = point - a;
-	float product = cross(u, v);
-	return sign(product);
-}
-
-
-inline bool bounded(Vector2 a, Vector2 b, Vector2 point) {
-	Vector2 ba = b - a;
-	if (std::abs(ba.x) > std::abs(ba.y)) { // line more horizontally oriented
-		// we check that we are bounded on x
-		if (ba.x > 0) { // positive dx means b.x > a.x
-			return point.x >= a.x && point.x <=b.x;
-		} else { // negative dx means that b.x < a.x
-			return point.x >= b.x && point.x <=a.x;
-		}
-	} else { // line is more vertically oriented
-		// we check that we are bounded on y
-		if (ba.y > 0) { // positive dy means b.y > a.y
-			return point.y >= a.y && point.y <= b.y;
-		} else { // negative dy means that a.y > b.y
-			return point.y >= b.y && point.y <= a.y;
-		}
-	}
-	assert(false);
-}


### PR DESCRIPTION
windows.h includes some other windows headers that define a function called 
`Polygon` which clashes with our `struct Polygon<T>` I tried everything to avoid the collision 
and in the end putting our type in a namespace seems like the only long term solution.

I also broke up the `maths.hpp` header because it had a lot in there and it felt confusing that to get shapes you needed to include maths, makes more sense to include shapes, same deal with vector2, it moved to it's own header. Maths is just misc math function that don't cleanly fit into other headers.
(like `sideSign` and `findNormal` and `bounded`)

NOTE: Moving forward do not put `using namespace <anything>` in a header, this will cause any file that `#include`s that header to also be `using` that namespace (this is why our headers all specifically reference the `wabi` namespace with `wabi::`